### PR TITLE
fix(deployment.yaml): add an emptyDir volume for /ark/config

### DIFF
--- a/charts/ark-cluster/Chart.yaml
+++ b/charts/ark-cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ark-cluster
-version: 0.2.1
+version: 0.2.2
 description: A Helm chart for an Ark - Survival Evolved cluster
 type: application
 appVersion: latest

--- a/charts/ark-cluster/templates/deployment.yaml
+++ b/charts/ark-cluster/templates/deployment.yaml
@@ -209,7 +209,7 @@ spec:
             - mountPath: /arkconfig
               name: {{ $chart_name }}-config-volume
             - mountPath: /ark/config
-              name: {{ $chart_name }}-config-bis-volume
+              name: {{ $chart_name }}-config-base-volume
             - mountPath: /ark/config/crontab
               name: {{ $chart_name }}-crontab-volume
               subPath: "crontab"
@@ -240,7 +240,7 @@ spec:
         - name: {{ $chart_name }}-config-volume
           configMap:
             name: {{ $chart_name }}-{{ $name }}
-        - name: {{ $chart_name }}-config-bis-volume
+        - name: {{ $chart_name }}-config-base-volume
           emptyDir:
         - name: {{ $chart_name }}-crontab-volume
           configMap:

--- a/charts/ark-cluster/templates/deployment.yaml
+++ b/charts/ark-cluster/templates/deployment.yaml
@@ -209,6 +209,8 @@ spec:
             - mountPath: /arkconfig
               name: {{ $chart_name }}-config-volume
             - mountPath: /ark/config
+              name: {{ $chart_name }}-config-bis-volume
+            - mountPath: /ark/config/crontab
               name: {{ $chart_name }}-crontab-volume
               subPath: "crontab"
               readOnly: true
@@ -238,6 +240,8 @@ spec:
         - name: {{ $chart_name }}-config-volume
           configMap:
             name: {{ $chart_name }}-{{ $name }}
+        - name: {{ $chart_name }}-config-bis-volume
+          emptyDir:
         - name: {{ $chart_name }}-crontab-volume
           configMap:
             name: {{ $chart_name }}-{{ $name }}


### PR DESCRIPTION
With the actual mount, /ark/config is a file instead of a directory.

If we only fix the path to /ark/config/crontab their is permission issues with /ark/config that's why i created an emptyDir